### PR TITLE
Removed Deprecated Endpoint and Deprecated Operation as entities

### DIFF
--- a/src/main/java/com/qdesrame/openapi/diff/model/ChangedEndpoint.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/ChangedEndpoint.java
@@ -4,6 +4,7 @@ import io.swagger.oas.models.Operation;
 import io.swagger.oas.models.PathItem;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 public class ChangedEndpoint implements Changed {
@@ -14,7 +15,6 @@ public class ChangedEndpoint implements Changed {
 
     private Map<PathItem.HttpMethod, Operation> newOperations;
     private Map<PathItem.HttpMethod, Operation> missingOperations;
-    private Map<PathItem.HttpMethod, Operation> deprecatedOperations;
     private Map<PathItem.HttpMethod, ChangedOperation> changedOperations;
 
     public ChangedEndpoint(String pathUrl, PathItem oldPathItem, PathItem newPathItem) {
@@ -57,15 +57,22 @@ public class ChangedEndpoint implements Changed {
         return changedOperations;
     }
 
+    public Map<PathItem.HttpMethod, Operation> getDeprecatedOperations() {
+        return changedOperations.entrySet()
+                .stream()
+                .filter(p -> p.getValue().isDeprecated())
+                .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue().getNewOperation()));
+    }
+
     public void setChangedOperations(
             Map<PathItem.HttpMethod, ChangedOperation> changedOperations) {
         this.changedOperations = changedOperations;
     }
 
     public boolean isDiff() {
-		return !newOperations.isEmpty()
-		|| !missingOperations.isEmpty()
-		|| !changedOperations.isEmpty();
+        return !newOperations.isEmpty()
+                || !missingOperations.isEmpty()
+                || !changedOperations.isEmpty();
     }
 
     @Override
@@ -79,15 +86,4 @@ public class ChangedEndpoint implements Changed {
         return String.format("Changed endpoint '%s': %d missing, %d changed", pathUrl, getMissingOperations().size(), getChangedOperations().size());
     }
 
-    public void setDeprecatedOperations(Map<PathItem.HttpMethod,Operation> deprecatedOperations) {
-        this.deprecatedOperations = deprecatedOperations;
-    }
-
-    public Map<PathItem.HttpMethod,Operation> getDeprecatedOperations() {
-        return deprecatedOperations;
-    }
-
-    public boolean isDeprecated() {
-        return !deprecatedOperations.isEmpty();
-    }
 }

--- a/src/main/java/com/qdesrame/openapi/diff/model/ChangedOpenApi.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/ChangedOpenApi.java
@@ -1,7 +1,9 @@
 package com.qdesrame.openapi.diff.model;
 
+import com.qdesrame.openapi.diff.utils.EndpointUtils;
 import io.swagger.oas.models.OpenAPI;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -13,7 +15,6 @@ public class ChangedOpenApi implements Changed {
 
     private List<Endpoint> newEndpoints;
     private List<Endpoint> missingEndpoints;
-    private List<Endpoint> deprecatedEndpoints;
     private List<ChangedEndpoint> changedEndpoints;
 
     public OpenAPI getOldSpecOpenApi() {
@@ -49,11 +50,9 @@ public class ChangedOpenApi implements Changed {
     }
 
     public List<Endpoint> getDeprecatedEndpoints() {
-        return deprecatedEndpoints;
-    }
-
-    public void setDeprecatedEndpoints(List<Endpoint> deprecatedEndpoints) {
-        this.deprecatedEndpoints = deprecatedEndpoints;
+        return changedEndpoints.stream()
+                .map(c -> EndpointUtils.convert2EndpointList(c.getPathUrl(), c.getDeprecatedOperations()))
+                .collect(ArrayList::new, List::addAll, List::addAll);
     }
 
     public List<ChangedEndpoint> getChangedEndpoints() {
@@ -68,7 +67,6 @@ public class ChangedOpenApi implements Changed {
     public boolean isDiff() {
         return newEndpoints.size() > 0
                 || missingEndpoints.size() > 0
-                || deprecatedEndpoints.size() > 0
                 || changedEndpoints.size() > 0;
     }
 
@@ -76,4 +74,5 @@ public class ChangedOpenApi implements Changed {
         return missingEndpoints.size() == 0
                 && changedEndpoints.stream().allMatch(c -> c.isDiffBackwardCompatible());
     }
+
 }

--- a/src/main/java/com/qdesrame/openapi/diff/model/ChangedOperation.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/ChangedOperation.java
@@ -67,7 +67,7 @@ public class ChangedOperation implements Changed {
 
     @Override
     public boolean isDiff() {
-        return isDiffParam() || isDiffRequest() || isDiffResponse();
+        return deprecated || isDiffParam() || isDiffRequest() || isDiffResponse();
     }
 
     @Override

--- a/src/main/java/com/qdesrame/openapi/diff/utils/EndpointUtils.java
+++ b/src/main/java/com/qdesrame/openapi/diff/utils/EndpointUtils.java
@@ -1,0 +1,56 @@
+package com.qdesrame.openapi.diff.utils;
+
+import com.qdesrame.openapi.diff.model.Endpoint;
+import io.swagger.oas.models.Operation;
+import io.swagger.oas.models.PathItem;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by adarsh.sharma on 26/12/17.
+ */
+public class EndpointUtils {
+    public static Collection<? extends Endpoint> convert2EndpointList(String pathUrl,
+                                                                Map<PathItem.HttpMethod, Operation> map) {
+        List<Endpoint> endpoints = new ArrayList<Endpoint>();
+        if (null == map) return endpoints;
+        for (Map.Entry<PathItem.HttpMethod, Operation> entry : map.entrySet()) {
+            PathItem.HttpMethod httpMethod = entry.getKey();
+            Operation operation = entry.getValue();
+            Endpoint endpoint = new Endpoint();
+            endpoint.setPathUrl(pathUrl);
+            endpoint.setMethod(httpMethod);
+            endpoint.setSummary(operation.getSummary());
+            endpoint.setOperation(operation);
+            endpoints.add(endpoint);
+        }
+        return endpoints;
+    }
+
+    public static List<Endpoint> convert2EndpointList(Map<String, PathItem> map) {
+        List<Endpoint> endpoints = new ArrayList<Endpoint>();
+        if (null == map) return endpoints;
+        for (Map.Entry<String, PathItem> entry : map.entrySet()) {
+            String url = entry.getKey();
+            PathItem path = entry.getValue();
+
+            Map<PathItem.HttpMethod, Operation> operationMap = path.readOperationsMap();
+            for (Map.Entry<PathItem.HttpMethod, Operation> entryOper : operationMap.entrySet()) {
+                PathItem.HttpMethod httpMethod = entryOper.getKey();
+                Operation operation = entryOper.getValue();
+
+                Endpoint endpoint = new Endpoint();
+                endpoint.setPathUrl(url);
+                endpoint.setMethod(httpMethod);
+                endpoint.setSummary(operation.getSummary());
+                endpoint.setPath(path);
+                endpoint.setOperation(operation);
+                endpoints.add(endpoint);
+            }
+        }
+        return endpoints;
+    }
+}


### PR DESCRIPTION
Because deprecated and changed are not mutually exclusive. 
Currently getDeprecatedEndpoints and getDeprecatedOperations is being returned by a method which we should ideally remove.
All deprecated operations/endpoints will reflect in changed operations/endpoints