### PR TITLE
feature: adds docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM maven:3.5-jdk-8-alpine as build
+WORKDIR /app
+COPY ./ /app
+RUN mvn install -q && \
+  mvn package -q && \
+  ls /app/target/ && \
+  MVN_VERSION=$(mvn -q \
+    -Dexec.executable="echo" \
+    -Dexec.args='${project.version}' \
+    --non-recursive \
+    org.codehaus.mojo:exec-maven-plugin:1.6.0:exec) && \
+  mv /app/target/openapi-diff-${MVN_VERSION}-jar-with-dependencies.jar /app/openapi-diff.jar
+
+FROM openjdk:8-jre-alpine
+WORKDIR /app
+COPY --from=0 /app/openapi-diff.jar /app
+ENTRYPOINT ["java", "-jar", "/app/openapi-diff.jar"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -274,6 +274,24 @@ try {
         Changed response : [200] //successful operation
 ```
 
+# Docker
+
+## Build image
+```bash
+docker build -t openapi-diff .
+```
+
+## Run an instance
+
+In this example the `$(pwd)/src/test/resources` directory is mounted in the `/specs` directory of the container
+in readonly mode (`ro`).
+
+```bash
+docker run -t \
+  -v $(pwd)/src/test/resources:/specs:ro \
+  openapi-diff /specs/path_1.yaml /specs/path_2.yaml
+```
+
 # License
 openapi-diff is released under the Apache License 2.0.
 

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,15 @@
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This PR adds the ability to run `openapi-diff` inside a Docker container.

I had to adjust the pom.xml file because the `jar-with-dependencies` archive wasn't being generated on `mvn package` and with the other jar files I was getting the  `no main manifest attribute, in "xxxx.jar` error.

How it works?
- The Docker build process is separated in two stages, so the final Docker image will be more lightweight and won't need maven inside (just 88.8MB).
- The first stage generates the 'jar' executable using maven. The Dockerfile auto-detects the version from the `pom.xml` file in order to use the proper `jar`.
- The second stage just exposes it using a simple openjdk container.

Now the missing part is publishing/pushing the image to Docker Hub. I guess you'll want to do that under your own account.
After that the "Build image" part won't be required anymore (as described in the readme changes I added) for the end users.

The nice thing is that once you create the project on Docker hub and configure it, you can have automated builds on every new (tag) release:
https://docs.docker.com/docker-hub/builds/

If you need any help on that just let me know.