### PR TITLE
Vendor extensions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ try {
 }
 ```
 
+### Extensions
+This project uses Java Service Provider Inteface (SPI) so additional extensions can be added. 
+
+To build your own extension, you simply need to create a `src/main/resources/META-INF/services/com.qdesrame.openapi.diff.compare.ExtensionDiff` file with the full classname of your implementation.  Your class must also implement the `com.qdesrame.openapi.diff.compare.ExtensionDiff` interface.  Then, including your library with the `openapi-diff` module will cause it to be triggered automatically.
+
 # Example
 ### CLI Output
 

--- a/src/main/java/com/qdesrame/openapi/diff/compare/ContentDiff.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/ContentDiff.java
@@ -36,7 +36,7 @@ public class ContentDiff implements Comparable<Content> {
             MediaType oldMediaType = left.get(mediaTypeKey);
             MediaType newMediaType = right.get(mediaTypeKey);
             ChangedMediaType changedMediaType = new ChangedMediaType(oldMediaType.getSchema(), newMediaType.getSchema(), context);
-            openApiDiff.getSchemaDiff().diff(new HashSet<>(), oldMediaType.getSchema(), newMediaType.getSchema(), context).ifPresent(changedMediaType::setChangedSchema);
+            openApiDiff.getSchemaDiff().diff(new HashSet<>(), oldMediaType.getSchema(), newMediaType.getSchema(), context.copyWithRequired(true)).ifPresent(changedMediaType::setChangedSchema);
             if (!isUnchanged(changedMediaType)) {
                 changedMediaTypes.put(mediaTypeKey, changedMediaType);
             }

--- a/src/main/java/com/qdesrame/openapi/diff/compare/ExtensionDiff.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/ExtensionDiff.java
@@ -1,0 +1,15 @@
+package com.qdesrame.openapi.diff.compare;
+
+import com.qdesrame.openapi.diff.model.Changed;
+import com.qdesrame.openapi.diff.model.DiffContext;
+
+import java.util.Optional;
+
+public interface ExtensionDiff {
+
+    ExtensionDiff setOpenApiDiff(OpenApiDiff openApiDiff);
+
+    String getName();
+
+    Optional<Changed> diff(Object left, Object right, DiffContext context);
+}

--- a/src/main/java/com/qdesrame/openapi/diff/compare/ExtensionsDiff.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/ExtensionsDiff.java
@@ -1,0 +1,43 @@
+package com.qdesrame.openapi.diff.compare;
+
+import com.qdesrame.openapi.diff.model.DiffContext;
+import com.qdesrame.openapi.diff.model.schema.ChangedExtensions;
+
+import java.util.*;
+
+import static com.qdesrame.openapi.diff.utils.ChangedUtils.isChanged;
+
+public class ExtensionsDiff {
+    private final OpenApiDiff openApiDiff;
+
+    private ServiceLoader<ExtensionDiff> extensionsLoader = ServiceLoader.load(ExtensionDiff.class);
+    private List<ExtensionDiff> extensionsDiff = new ArrayList<>();
+
+    public ExtensionsDiff(OpenApiDiff openApiDiff) {
+        this.openApiDiff = openApiDiff;
+        this.extensionsLoader.reload();
+        for (ExtensionDiff anExtensionsLoader : this.extensionsLoader) {
+            extensionsDiff.add(anExtensionsLoader);
+        }
+    }
+
+    public Optional<ChangedExtensions> diff(Map<String, Object> left, Map<String, Object> right, DiffContext context) {
+        if (null == left) left = new HashMap<>();
+        if (null == right) right = new HashMap<>();
+        ChangedExtensions changedExtensions = new ChangedExtensions(left, new HashMap<>(right), context);
+        changedExtensions.getIncreased().putAll(right);
+        for (String key : left.keySet()) {
+            if (changedExtensions.getIncreased().containsKey(key)) {
+                Optional<ExtensionDiff> extensionDiff = extensionsDiff.stream()
+                        .filter(diff -> ("x-" + diff.getName()).equals(key)).findFirst();
+                Object leftValue = left.get(key);
+                Object rightValue = changedExtensions.getIncreased().remove(key);
+                extensionDiff.ifPresent(diff -> diff.setOpenApiDiff(openApiDiff).diff(leftValue, rightValue, context)
+                        .ifPresent(changed -> changedExtensions.getChanged().put(key, changed)));
+            } else {
+                changedExtensions.getMissing().put(key, left.get(key));
+            }
+        }
+        return isChanged(changedExtensions);
+    }
+}

--- a/src/main/java/com/qdesrame/openapi/diff/compare/HeaderDiff.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/HeaderDiff.java
@@ -44,7 +44,7 @@ public class HeaderDiff extends ReferenceDiffCache<Header, ChangedHeader> {
         changedHeader.setChangeDeprecated(!Boolean.TRUE.equals(left.getDeprecated()) && Boolean.TRUE.equals(right.getDeprecated()));
         changedHeader.setChangeStyle(!Objects.equals(left.getStyle(), right.getStyle()));
         changedHeader.setChangeExplode(getBooleanDiff(left.getExplode(), right.getExplode()));
-        openApiDiff.getSchemaDiff().diff(new HashSet<>(), left.getSchema(), right.getSchema(), context).ifPresent(changedHeader::setChangedSchema);
+        openApiDiff.getSchemaDiff().diff(new HashSet<>(), left.getSchema(), right.getSchema(), context.copyWithRequired(true)).ifPresent(changedHeader::setChangedSchema);
         openApiDiff.getContentDiff().diff(left.getContent(), right.getContent(), context).ifPresent(changedHeader::setChangedContent);
 
         return isChanged(changedHeader);

--- a/src/main/java/com/qdesrame/openapi/diff/compare/OpenApiDiff.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/OpenApiDiff.java
@@ -40,6 +40,7 @@ public class OpenApiDiff {
     private SecuritySchemeDiff securitySchemeDiff;
     private OAuthFlowsDiff oAuthFlowsDiff;
     private OAuthFlowDiff oAuthFlowDiff;
+    private ExtensionsDiff extensionsDiff;
 
     private OpenAPI oldSpecOpenApi;
     private OpenAPI newSpecOpenApi;
@@ -84,6 +85,7 @@ public class OpenApiDiff {
         this.securitySchemeDiff = new SecuritySchemeDiff(this);
         this.oAuthFlowsDiff = new OAuthFlowsDiff(this);
         this.oAuthFlowDiff = new OAuthFlowDiff(this);
+        this.extensionsDiff = new ExtensionsDiff(this);
     }
 
     private ChangedOpenApi compare() {
@@ -199,6 +201,10 @@ public class OpenApiDiff {
 
     public OAuthFlowDiff getoAuthFlowDiff() {
         return oAuthFlowDiff;
+    }
+
+    public ExtensionsDiff getExtensionsDiff() {
+        return extensionsDiff;
     }
 
     public OpenAPI getOldSpecOpenApi() {

--- a/src/main/java/com/qdesrame/openapi/diff/compare/ParameterDiff.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/ParameterDiff.java
@@ -46,7 +46,7 @@ public class ParameterDiff extends ReferenceDiffCache<Parameter, ChangedParamete
         changedParameter.setChangeAllowEmptyValue(getBooleanDiff(left.getAllowEmptyValue(), right.getAllowEmptyValue()));
         changedParameter.setChangeStyle(!Objects.equals(left.getStyle(), right.getStyle()));
         changedParameter.setChangeExplode(getBooleanDiff(left.getExplode(), right.getExplode()));
-        Optional<ChangedSchema> changedSchema = openApiDiff.getSchemaDiff().diff(refSet, left.getSchema(), right.getSchema(), context);
+        Optional<ChangedSchema> changedSchema = openApiDiff.getSchemaDiff().diff(refSet, left.getSchema(), right.getSchema(), context.copyWithRequired(true));
         if (changedSchema.isPresent()) {
             changedParameter.setChangedSchema(changedSchema.get());
         }

--- a/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/ArraySchemaDiffResult.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/ArraySchemaDiffResult.java
@@ -22,6 +22,6 @@ public class ArraySchemaDiffResult extends SchemaDiffResult {
     public Optional<ChangedSchema> diff(HashSet<String> refSet, Components leftComponents, Components rightComponents, Schema left, Schema right, DiffContext context) {
         ArraySchema leftArraySchema = (ArraySchema) left;
         ArraySchema rightArraySchema = (ArraySchema) right;
-        return openApiDiff.getSchemaDiff().diff(refSet, leftArraySchema.getItems(), rightArraySchema.getItems(), context);
+        return openApiDiff.getSchemaDiff().diff(refSet, leftArraySchema.getItems(), rightArraySchema.getItems(), context.copyWithRequired(true));
     }
 }

--- a/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/ComposedSchemaDiffResult.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/ComposedSchemaDiffResult.java
@@ -66,7 +66,7 @@ public class ComposedSchemaDiffResult extends SchemaDiffResult {
                     leftSchema.set$ref(leftMapping.get(key));
                     Schema rightSchema = new Schema();
                     rightSchema.set$ref(rightMapping.get(key));
-                    Optional<ChangedSchema> changedSchema = openApiDiff.getSchemaDiff().diff(refSet, leftSchema, rightSchema, context);
+                    Optional<ChangedSchema> changedSchema = openApiDiff.getSchemaDiff().diff(refSet, leftSchema, rightSchema, context.copyWithRequired(true));
                     changedSchema.ifPresent(schema -> changedMapping.put(key, schema));
                 }
                 changedSchema.setChangedOneOfSchema(changedOneOfSchema);

--- a/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/SchemaDiffResult.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/SchemaDiffResult.java
@@ -5,6 +5,7 @@ import com.qdesrame.openapi.diff.compare.OpenApiDiff;
 import com.qdesrame.openapi.diff.model.ChangedSchema;
 import com.qdesrame.openapi.diff.model.DiffContext;
 import com.qdesrame.openapi.diff.model.ListDiff;
+import com.qdesrame.openapi.diff.model.schema.ChangedExtensions;
 import com.qdesrame.openapi.diff.model.schema.ChangedReadOnly;
 import com.qdesrame.openapi.diff.model.schema.ChangedWriteOnly;
 import io.swagger.v3.oas.models.Components;
@@ -47,6 +48,8 @@ public class SchemaDiffResult {
         changedSchema.setChangedReadOnly(new ChangedReadOnly(context, left.getReadOnly(), right.getReadOnly()));
         changedSchema.setChangedWriteOnly(new ChangedWriteOnly(context, left.getWriteOnly(), right.getWriteOnly()));
         changedSchema.setChangedMaxLength(!Objects.equals(left.getMaxLength(), right.getMaxLength()));
+        Optional<ChangedExtensions> changedExtensions = openApiDiff.getExtensionsDiff().diff(left.getExtensions(), right.getExtensions(), context);
+        changedExtensions.ifPresent(changedSchema::setChangedExtensions);
 
         Map<String, Schema> leftProperties = null == left ? null : left.getProperties();
         Map<String, Schema> rightProperties = null == right ? null : right.getProperties();

--- a/src/main/java/com/qdesrame/openapi/diff/model/ChangedSchema.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/ChangedSchema.java
@@ -1,5 +1,6 @@
 package com.qdesrame.openapi.diff.model;
 
+import com.qdesrame.openapi.diff.model.schema.ChangedExtensions;
 import com.qdesrame.openapi.diff.model.schema.ChangedReadOnly;
 import com.qdesrame.openapi.diff.model.schema.ChangedWriteOnly;
 import com.qdesrame.openapi.diff.utils.ChangedUtils;
@@ -38,6 +39,7 @@ public class ChangedSchema implements Changed {
     protected boolean discriminatorPropertyChanged;
     protected ChangedOneOfSchema changedOneOfSchema;
     protected ChangedSchema addPropChangedSchema;
+    protected ChangedExtensions changedExtensions;
 
     public ChangedSchema() {
         increasedProperties = new HashMap<>();
@@ -53,7 +55,8 @@ public class ChangedSchema implements Changed {
                 && !changeFormat && increasedProperties.size() == 0 && missingProperties.size() == 0
                 && changedProperties.values().size() == 0 && !changeDeprecated
                 && (changeRequired == null || changeRequired.isUnchanged()) && !discriminatorPropertyChanged
-                && ChangedUtils.isUnchanged(addPropChangedSchema) && ChangedUtils.isUnchanged(changedOneOfSchema)) {
+                && ChangedUtils.isUnchanged(addPropChangedSchema) && ChangedUtils.isUnchanged(changedOneOfSchema)
+                && ChangedUtils.isUnchanged(changedExtensions)) {
             return DiffResult.NO_CHANGES;
         }
         boolean backwardCompatibleForRequest = (changeEnum == null || changeEnum.getMissing().isEmpty()) &&
@@ -71,7 +74,8 @@ public class ChangedSchema implements Changed {
         if ((context.isRequest() && backwardCompatibleForRequest || context.isResponse() && backwardCompatibleForResponse)
                 && !changedType && !discriminatorPropertyChanged && ChangedUtils.isCompatible(changedOneOfSchema)
                 && ChangedUtils.isCompatible(addPropChangedSchema)
-                && changedProperties.values().stream().allMatch(Changed::isCompatible)) {
+                && changedProperties.values().stream().allMatch(Changed::isCompatible)
+                && ChangedUtils.isCompatible(changedExtensions)) {
             return DiffResult.COMPATIBLE;
         }
 

--- a/src/main/java/com/qdesrame/openapi/diff/model/DiffContext.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/DiffContext.java
@@ -17,6 +17,7 @@ public class DiffContext {
     private PathItem.HttpMethod method;
     private boolean response;
     private boolean request;
+    private Boolean required;
 
     public DiffContext() {
         parameters = new HashMap<>();
@@ -26,6 +27,10 @@ public class DiffContext {
 
     public DiffContext copyWithMethod(PathItem.HttpMethod method) {
         return copy().setMethod(method);
+    }
+
+    public DiffContext copyWithRequired(boolean required) {
+        return copy().setRequired(required);
     }
 
     public DiffContext copyAsRequest() {
@@ -81,6 +86,7 @@ public class DiffContext {
         context.method = this.method;
         context.response = this.response;
         context.request = this.request;
+        context.required = this.required;
         return context;
     }
 
@@ -90,6 +96,15 @@ public class DiffContext {
 
     public DiffContext setParameters(Map<String, String> parameters) {
         this.parameters = parameters;
+        return this;
+    }
+
+    public Boolean isRequired() {
+        return required;
+    }
+
+    private DiffContext setRequired(boolean required) {
+        this.required = required;
         return this;
     }
 
@@ -107,6 +122,7 @@ public class DiffContext {
                 .append(url, that.url)
                 .append(parameters, that.parameters)
                 .append(method, that.method)
+                .append(required, that.required)
                 .isEquals();
     }
 
@@ -118,6 +134,7 @@ public class DiffContext {
                 .append(method)
                 .append(response)
                 .append(request)
+                .append(required)
                 .toHashCode();
     }
 }

--- a/src/main/java/com/qdesrame/openapi/diff/model/schema/ChangedExtensions.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/schema/ChangedExtensions.java
@@ -1,0 +1,42 @@
+package com.qdesrame.openapi.diff.model.schema;
+
+import com.qdesrame.openapi.diff.model.Changed;
+import com.qdesrame.openapi.diff.model.DiffContext;
+import com.qdesrame.openapi.diff.model.DiffResult;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+@Setter
+public class ChangedExtensions implements Changed {
+    private final Map<String, Object> oldExtensions;
+    private final Map<String, Object> newExtensions;
+    private final DiffContext context;
+
+    private Map<String, Object> increased;
+    private Map<String, Object> missing;
+    private Map<String, Changed> changed;
+
+    public ChangedExtensions(Map<String, Object> oldExtensions, Map<String, Object> newExtensions, DiffContext context) {
+        this.oldExtensions = oldExtensions;
+        this.newExtensions = newExtensions;
+        this.context = context;
+        this.increased = new LinkedHashMap<>();
+        this.missing = new LinkedHashMap<>();
+        this.changed = new LinkedHashMap<>();
+    }
+
+    @Override
+    public DiffResult isChanged() {
+        if (increased.isEmpty() && missing.isEmpty() && changed.isEmpty()) {
+            return DiffResult.NO_CHANGES;
+        }
+        if (changed.values().stream().allMatch(Changed::isCompatible)) {
+            return DiffResult.COMPATIBLE;
+        }
+        return DiffResult.INCOMPATIBLE;
+    }
+}

--- a/src/main/java/com/qdesrame/openapi/diff/model/schema/ChangedReadOnly.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/schema/ChangedReadOnly.java
@@ -30,9 +30,9 @@ public class ChangedReadOnly implements Changed {
         }
         if (context.isRequest()) {
             if (Boolean.TRUE.equals(newValue)) {
-                return DiffResult.COMPATIBLE;
-            } else {
                 return DiffResult.INCOMPATIBLE;
+            } else {
+                return context.isRequired() ? DiffResult.INCOMPATIBLE : DiffResult.COMPATIBLE;
             }
         }
         return DiffResult.UNKNOWN;

--- a/src/main/java/com/qdesrame/openapi/diff/model/schema/ChangedWriteOnly.java
+++ b/src/main/java/com/qdesrame/openapi/diff/model/schema/ChangedWriteOnly.java
@@ -32,7 +32,7 @@ public class ChangedWriteOnly implements Changed {
             if (Boolean.TRUE.equals(newValue)) {
                 return DiffResult.INCOMPATIBLE;
             } else {
-                return DiffResult.COMPATIBLE;
+                return context.isRequired() ? DiffResult.INCOMPATIBLE : DiffResult.COMPATIBLE;
             }
         }
         return DiffResult.UNKNOWN;


### PR DESCRIPTION
Support OpenAPI vendor extensions in this diff tools. Extensions can be supported by extending interface `com.qdesrame.openapi.diff.compare.ExtensionDiff`