### PR TITLE
Fix NullPointerException with oneOf discriminator change

### DIFF
--- a/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/ComposedSchemaDiffResult.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/schemadiffresult/ComposedSchemaDiffResult.java
@@ -46,6 +46,7 @@ public class ComposedSchemaDiffResult extends SchemaDiffResult {
                     changedSchema.setOldSchema(left);
                     changedSchema.setNewSchema(right);
                     changedSchema.setDiscriminatorPropertyChanged(true);
+                    changedSchema.setContext(context);
                     return Optional.of(changedSchema);
                 }
 

--- a/src/test/java/com/qdesrame/openapi/test/OneOfDiffTest.java
+++ b/src/test/java/com/qdesrame/openapi/test/OneOfDiffTest.java
@@ -16,6 +16,8 @@ public class OneOfDiffTest {
     private final String OPENAPI_DOC3 = "oneOf_diff_3.yaml";
     private final String OPENAPI_DOC4 = "composed_schema_1.yaml";
     private final String OPENAPI_DOC5 = "composed_schema_2.yaml";
+    private final String OPENAPI_DOC6 = "oneOf_discriminator-changed_1.yaml";
+    private final String OPENAPI_DOC7 = "oneOf_discriminator-changed_2.yaml";
 
     @Test
     public void testDiffSame() {
@@ -35,6 +37,12 @@ public class OneOfDiffTest {
     @Test
     public void testComposedSchema() {
         assertOpenApiBackwardIncompatible(OPENAPI_DOC4, OPENAPI_DOC5);
+    }
+
+    @Test
+    public void testOneOfDiscrimitatorChanged() {
+        //The oneOf 'discriminator' changed: 'realtype' -> 'othertype':
+        assertOpenApiBackwardIncompatible(OPENAPI_DOC6, OPENAPI_DOC7);
     }
 
 }

--- a/src/test/resources/oneOf_discriminator-changed_1.yaml
+++ b/src/test/resources/oneOf_discriminator-changed_1.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.1
+info:
+  title: oneOf test for issue 29
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8000/'
+paths:
+  /state:
+    post:
+      operationId: update
+      requestBody:
+        content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/A'
+                  - $ref: '#/components/schemas/B'
+                discriminator:
+                  propertyName: realtype
+                  mapping:
+                    a-type: '#/components/schemas/A'
+                    b-type: '#/components/schemas/B'
+        required: true
+      responses:
+        '201':
+          description: OK
+components:
+  schemas:
+    A:
+      type: object
+      properties:
+        realtype:
+          type: string
+        othertype:
+          type: string
+        message:
+          type: string
+    B:
+      type: object
+      properties:
+        realtype:
+          type: string
+        othertype:
+          type: string
+        description:
+          type: string
+        code:
+          type: integer
+          format: int32

--- a/src/test/resources/oneOf_discriminator-changed_2.yaml
+++ b/src/test/resources/oneOf_discriminator-changed_2.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.1
+info:
+  title: oneOf test for issue 29
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8000/'
+paths:
+  /state:
+    post:
+      operationId: update
+      requestBody:
+        content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/A'
+                  - $ref: '#/components/schemas/B'
+                discriminator:
+                  propertyName: othertype
+                  mapping:
+                    a-type: '#/components/schemas/A'
+                    b-type: '#/components/schemas/B'
+        required: true
+      responses:
+        '201':
+          description: OK
+components:
+  schemas:
+    A:
+      type: object
+      properties:
+        realtype:
+          type: string
+        othertype:
+          type: string
+        message:
+          type: string
+    B:
+      type: object
+      properties:
+        realtype:
+          type: string
+        othertype:
+          type: string
+        description:
+          type: string
+        code:
+          type: integer
+          format: int32


### PR DESCRIPTION
While I was working on #29, I have found a NullPointerException:

```
java.lang.NullPointerException
	at com.qdesrame.openapi.diff.model.ChangedSchema.isChanged(ChangedSchema.java:76)
	at com.qdesrame.openapi.diff.model.Changed.isUnchanged(Changed.java:15)
	at com.qdesrame.openapi.diff.model.ChangedMediaType.isChanged(ChangedMediaType.java:23)
	at com.qdesrame.openapi.diff.model.Changed.isUnchanged(Changed.java:15)
	at com.qdesrame.openapi.diff.utils.ChangedUtils.isUnchanged(ChangedUtils.java:10)
	at com.qdesrame.openapi.diff.compare.ContentDiff.diff(ContentDiff.java:40)
	at com.qdesrame.openapi.diff.compare.RequestBodyDiff.computeDiff(RequestBodyDiff.java:61)
	at com.qdesrame.openapi.diff.compare.RequestBodyDiff.computeDiff(RequestBodyDiff.java:1)
	at com.qdesrame.openapi.diff.compare.ReferenceDiffCache.cachedDiff(ReferenceDiffCache.java:48)
	at com.qdesrame.openapi.diff.compare.RequestBodyDiff.diff(RequestBodyDiff.java:30)
	at com.qdesrame.openapi.diff.compare.OperationDiff.diff(OperationDiff.java:32)
	at com.qdesrame.openapi.diff.compare.PathDiff.diff(PathDiff.java:34)
	at com.qdesrame.openapi.diff.compare.PathsDiff.lambda$0(PathsDiff.java:59)
	at java.util.LinkedHashMap$LinkedKeySet.forEach(LinkedHashMap.java:559)
	at com.qdesrame.openapi.diff.compare.PathsDiff.diff(PathsDiff.java:39)
	at com.qdesrame.openapi.diff.compare.OpenApiDiff.compare(OpenApiDiff.java:94)
	at com.qdesrame.openapi.diff.compare.OpenApiDiff.compare(OpenApiDiff.java:67)
	at com.qdesrame.openapi.diff.OpenApiCompare.fromSpecifications(OpenApiCompare.java:99)
	at com.qdesrame.openapi.diff.OpenApiCompare.fromLocations(OpenApiCompare.java:88)
	at com.qdesrame.openapi.diff.OpenApiCompare.fromLocations(OpenApiCompare.java:76)
```

This PR fix it an add a test.