### PR TITLE
Fix for https://github.com/quen2404/openapi-diff/issues/58

### DIFF
--- a/src/main/java/com/qdesrame/openapi/diff/compare/SchemaDiff.java
+++ b/src/main/java/com/qdesrame/openapi/diff/compare/SchemaDiff.java
@@ -60,6 +60,9 @@ public class SchemaDiff extends ReferenceDiffCache<Schema, ChangedSchema> {
     }
 
     public Optional<ChangedSchema> diff(HashSet<String> refSet, Schema left, Schema right, DiffContext context) {
+        if (left == null || right == null) {
+            return Optional.empty();
+        }
         return cachedDiff(refSet, left, right, left.get$ref(), right.get$ref(), context);
     }
 


### PR DESCRIPTION
This provided a fix for #58 where a `NullPointerException` is thrown if a schema is formatted as in the issue.