### PR TITLE
add fail-on-incompatible option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ usage: openapi-diff <old> <new>
     --query <property=value>    use query param for authorisation
     --state                     Only output diff state: no_changes,
                                 incompatible, compatible
+    --fail-on-incompatible      Fail only if API changes broke backward compatibility
     --trace                     be extra verbose
     --version                   print the version information and exit
     --warn                      Print warning information

--- a/src/main/java/com/qdesrame/openapi/diff/Main.java
+++ b/src/main/java/com/qdesrame/openapi/diff/Main.java
@@ -30,11 +30,6 @@ public class Main {
             .build());
     options.addOption(
         Option.builder()
-            .longOpt("state")
-            .desc("Only output diff state: no_changes, incompatible, compatible")
-            .build());
-    options.addOption(
-        Option.builder()
             .longOpt("fail-on-incompatible")
             .desc("Fail only if API changes broke backward compatibility")
             .build());

--- a/src/main/java/com/qdesrame/openapi/diff/Main.java
+++ b/src/main/java/com/qdesrame/openapi/diff/Main.java
@@ -28,6 +28,16 @@ public class Main {
             .longOpt("state")
             .desc("Only output diff state: no_changes, incompatible, compatible")
             .build());
+    options.addOption(
+        Option.builder()
+            .longOpt("state")
+            .desc("Only output diff state: no_changes, incompatible, compatible")
+            .build());
+    options.addOption(
+        Option.builder()
+            .longOpt("fail-on-incompatible")
+            .desc("Fail only if API changes broke backward compatibility")
+            .build());
     options.addOption(Option.builder().longOpt("trace").desc("be extra verbose").build());
     options.addOption(
         Option.builder().longOpt("debug").desc("Print debugging information").build());
@@ -179,6 +189,8 @@ public class Main {
       if (line.hasOption("state")) {
         System.out.println(result.isChanged().getValue());
         System.exit(0);
+      } else if (line.hasOption("fail-on-incompatible")) {
+        System.exit(result.isCompatible() ? 0 : 1);
       } else {
         System.exit(result.isUnchanged() ? 0 : 1);
       }


### PR DESCRIPTION
I'm a trying to use this tool into my maven build and i want to fail build only if API changes broke backward compatibility. I'm manage to get the old version into ${basedir}/target/api-old.yaml.

With the --state option (#36) the exit code is always 0, i have to parse the stdout to get the status and i don't have the detail of changes.
With the --fail-on-incompatible the exit code 1 if  API changes broke backward compatibility.
```
<plugin>
	<artifactId>maven-antrun-plugin</artifactId>
	<version>1.8</version>
	<executions>
		<execution>
			<id>openapi-backward</id>
			<phase>validate</phase>
			<goals>
				<goal>run</goal>
			</goals>
			<configuration>
				<tasks>
					<java fork="true" failonerror="true" classname="com.qdesrame.openapi.diff.Main">
						<arg value="${basedir}/target/api-old.yaml" />
						<arg value="${project.basedir}/src/main/resources/api.yaml" />
						<arg value="--fail-on-incompatible" />
						<classpath refid="maven.plugin.classpath" />
					</java>
				</tasks>
			</configuration>
		</execution>
	</executions>
	<dependencies>
		<dependency>
			<groupId>com.qdesrame</groupId>
			<artifactId>openapi-diff</artifactId>
			<version>2.0.0-SNAPSHOT</version>
		</dependency>
	</dependencies>
</plugin>
```
