### PR TITLE
Report causes for compatibility breakage

### DIFF
--- a/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
+++ b/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
@@ -192,31 +192,31 @@ public class ConsoleRender implements Render {
                       .append(System.lineSeparator());
                 });
       }
-    } else {
-      if (changed instanceof ChangedSchema) {
-        ChangedSchema cs = (ChangedSchema) changed;
+    }
 
-        String description = null;
-        if (!cs.getChangedProperties().isEmpty()) {
-          description = cs.getChangedProperties().keySet().stream().collect(Collectors.joining());
-        } else if (cs.getItems() != null) {
-          description = "[n]";
-        }
-        final String prefix = propPrefix + description + ".";
-        cs.getChangedElements().stream()
-            .forEach(
-                (c) -> {
-                  if (c != null && c instanceof ComposedChanged) {
-                    incompatibility(output, (ComposedChanged) c, prefix);
-                  }
-                });
-        return;
+    if (changed instanceof ChangedSchema) {
+      ChangedSchema cs = (ChangedSchema) changed;
+
+      String description = null;
+      if (!cs.getChangedProperties().isEmpty()) {
+        description = cs.getChangedProperties().keySet().stream().collect(Collectors.joining());
+      } else if (cs.getItems() != null) {
+        description = "[n]";
       }
+      final String prefix = propPrefix + description + ".";
+      cs.getChangedElements().stream()
+          .forEach(
+              (c) -> {
+                if (c != null && c instanceof ComposedChanged) {
+                  incompatibility(output, (ComposedChanged) c, prefix);
+                }
+              });
+      return;
+    }
 
-      for (Changed child : changed.getChangedElements()) {
-        if (child instanceof ComposedChanged) {
-          incompatibility(output, (ComposedChanged) child, "");
-        }
+    for (Changed child : changed.getChangedElements()) {
+      if (child instanceof ComposedChanged) {
+        incompatibility(output, (ComposedChanged) child, "");
       }
     }
   }

--- a/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
+++ b/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
@@ -190,7 +190,13 @@ public class ConsoleRender implements Render {
       if (changed instanceof ChangedSchema) {
         ChangedSchema cs = (ChangedSchema) changed;
 
-        return cs.getChangedProperties().keySet().stream().collect(Collectors.joining())
+        String description = null;
+        if (!cs.getChangedProperties().isEmpty()) {
+          description = cs.getChangedProperties().keySet().stream().collect(Collectors.joining());
+        } else if (cs.getItems() != null) {
+          description = "[n]";
+        }
+        return description
             + "."
             + cs.getChangedElements().stream()
                 .map(

--- a/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
+++ b/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
@@ -187,7 +187,7 @@ public class ConsoleRender implements Render {
                       .append(StringUtils.repeat(' ', 10))
                       .append("Missing property: ")
                       .append(propPrefix)
-                      .append(".")
+                      .append(propPrefix.isEmpty() ? "" : ".")
                       .append(propName)
                       .append(System.lineSeparator());
                 });

--- a/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
+++ b/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
@@ -191,6 +191,14 @@ public class ConsoleRender implements Render {
                       .append(propName)
                       .append(System.lineSeparator());
                 });
+
+        if (cs.isChangedType()) {
+          output
+              .append(StringUtils.repeat(' ', 10))
+              .append("Changed property type: ")
+              .append(propPrefix)
+              .append(System.lineSeparator());
+        }
       }
     }
 

--- a/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
+++ b/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
@@ -3,6 +3,10 @@ package com.qdesrame.openapi.diff.output;
 import static com.qdesrame.openapi.diff.model.Changed.result;
 
 import com.qdesrame.openapi.diff.model.*;
+import com.qdesrame.openapi.diff.utils.RefPointer;
+import com.qdesrame.openapi.diff.utils.RefType;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import java.util.List;
@@ -13,11 +17,14 @@ import org.apache.commons.lang3.StringUtils;
 
 public class ConsoleRender implements Render {
   private static final int LINE_LENGTH = 74;
+  protected static RefPointer<Schema> refPointer = new RefPointer<>(RefType.SCHEMAS);
+  protected ChangedOpenApi diff;
 
   private StringBuilder output;
 
   @Override
   public String render(ChangedOpenApi diff) {
+    this.diff = diff;
     output = new StringBuilder();
     if (diff.isUnchanged()) {
       output.append("No differences. Specifications are equivalents");
@@ -169,64 +176,70 @@ public class ConsoleRender implements Render {
         .append(changedMediaType.isCompatible() ? "Backward compatible" : "Broken compatibility")
         .append(System.lineSeparator());
     if (!changedMediaType.isCompatible()) {
-      incompatibility(sb, changedMediaType, "");
+      sb.append(incompatibilities(changedMediaType.getSchema()));
     }
     return sb.toString();
   }
 
-  private void incompatibility(
-      final StringBuilder output, final ComposedChanged changed, final String propPrefix) {
-    if (changed.isCoreChanged() == DiffResult.INCOMPATIBLE) {
-      if (changed instanceof ChangedSchema) {
-        ChangedSchema cs = (ChangedSchema) changed;
+  private String incompatibilities(final ChangedSchema schema) {
+    return incompatibilities("", schema);
+  }
 
-        cs.getMissingProperties().keySet().stream()
-            .forEach(
-                (propName) -> {
-                  output
-                      .append(StringUtils.repeat(' ', 10))
-                      .append("Missing property: ")
-                      .append(propPrefix)
-                      .append(propPrefix.isEmpty() ? "" : ".")
-                      .append(propName)
-                      .append(System.lineSeparator());
-                });
-
-        if (cs.isChangedType()) {
-          output
-              .append(StringUtils.repeat(' ', 10))
-              .append("Changed property type: ")
-              .append(propPrefix)
-              .append(System.lineSeparator());
-        }
-      }
+  private String incompatibilities(String propName, final ChangedSchema schema) {
+    StringBuilder sb = new StringBuilder();
+    if (schema.getItems() != null) {
+      sb.append(items(propName, schema.getItems()));
     }
-
-    if (changed instanceof ChangedSchema) {
-      ChangedSchema cs = (ChangedSchema) changed;
-
-      String description = null;
-      if (!cs.getChangedProperties().isEmpty()) {
-        cs.getChangedProperties().entrySet().stream()
-            .forEach(
-                (entry) -> {
-                  incompatibility(
-                      output,
-                      entry.getValue(),
-                      propPrefix + (propPrefix.isEmpty() ? "" : ".") + entry.getKey());
-                });
-      } else if (cs.getItems() != null) {
-        incompatibility(output, cs.getItems(), propPrefix + "[n]");
-      }
-
-      return;
+    if (schema.isCoreChanged() == DiffResult.INCOMPATIBLE && schema.isChangedType()) {
+      String type = type(schema.getOldSchema()) + " -> " + type(schema.getNewSchema());
+      sb.append(property(propName, "Changed property type", type));
     }
+    String prefix = propName.isEmpty() ? "" : propName + ".";
+    sb.append(
+        properties(prefix, "Missing property", schema.getMissingProperties(), schema.getContext()));
+    schema
+        .getChangedProperties()
+        .forEach((name, property) -> sb.append(incompatibilities(prefix + name, property)));
+    return sb.toString();
+  }
 
-    for (Changed child : changed.getChangedElements()) {
-      if (child instanceof ComposedChanged) {
-        incompatibility(output, (ComposedChanged) child, "");
-      }
+  private String items(String propName, ChangedSchema schema) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(incompatibilities(propName + "[n]", schema));
+    return sb.toString();
+  }
+
+  private String properties(
+      String propPrefix, String title, Map<String, Schema> properties, DiffContext context) {
+    StringBuilder sb = new StringBuilder();
+    if (properties != null) {
+      properties.forEach(
+          (key, value) -> sb.append(property(propPrefix + key, title, resolve(value))));
     }
+    return sb.toString();
+  }
+
+  protected String property(String name, String title, Schema schema) {
+    return property(name, title, type(schema));
+  }
+
+  protected String property(String name, String title, String type) {
+    return String.format("%s%s: %s (%s)\n", StringUtils.repeat(' ', 10), title, name, type);
+  }
+
+  protected Schema resolve(Schema schema) {
+    return refPointer.resolveRef(
+        diff.getNewSpecOpenApi().getComponents(), schema, schema.get$ref());
+  }
+
+  protected String type(Schema schema) {
+    String result = "object";
+    if (schema instanceof ArraySchema) {
+      result = "array";
+    } else if (schema.getType() != null) {
+      result = schema.getType();
+    }
+    return result;
   }
 
   private String ul_param(ChangedParameters changedParameters) {

--- a/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
+++ b/src/main/java/com/qdesrame/openapi/diff/output/ConsoleRender.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.models.responses.ApiResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.lang3.StringUtils;
 
@@ -188,6 +187,7 @@ public class ConsoleRender implements Render {
                       .append(StringUtils.repeat(' ', 10))
                       .append("Missing property: ")
                       .append(propPrefix)
+                      .append(".")
                       .append(propName)
                       .append(System.lineSeparator());
                 });
@@ -199,18 +199,18 @@ public class ConsoleRender implements Render {
 
       String description = null;
       if (!cs.getChangedProperties().isEmpty()) {
-        description = cs.getChangedProperties().keySet().stream().collect(Collectors.joining());
+        cs.getChangedProperties().entrySet().stream()
+            .forEach(
+                (entry) -> {
+                  incompatibility(
+                      output,
+                      entry.getValue(),
+                      propPrefix + (propPrefix.isEmpty() ? "" : ".") + entry.getKey());
+                });
       } else if (cs.getItems() != null) {
-        description = "[n]";
+        incompatibility(output, cs.getItems(), propPrefix + "[n]");
       }
-      final String prefix = propPrefix + description + ".";
-      cs.getChangedElements().stream()
-          .forEach(
-              (c) -> {
-                if (c != null && c instanceof ComposedChanged) {
-                  incompatibility(output, (ComposedChanged) c, prefix);
-                }
-              });
+
       return;
     }
 


### PR DESCRIPTION
First of all, this is a work in progress. I'm trying to add details about broken compatibility and tried to start with properties removed from responses. Just let me know if I'm going in the right direction.

I'm currently getting the output below with this code ([old][gist_old] and [new][gist_new] specs available as a gist):

```
==========================================================================
==                            API CHANGE LOG                            ==
==========================================================================
                                  My API                                  
--------------------------------------------------------------------------
--                            What's Changed                            --
--------------------------------------------------------------------------
- GET    /api/v1/addons
  Return Type:
    - Changed 422 Unprocessable Entity
      Media types:
        - Changed application/json
          Schema: Broken compatibility
          Missing property: .originConstraint.leafBean
--------------------------------------------------------------------------
--                                Result                                --
--------------------------------------------------------------------------
                 API changes broke backward compatibility                 
--------------------------------------------------------------------------
```

I have added the `Missing property` line. The property path is a little rough right now, but I plan on working on this later. For this test case, my ideal output should be something along these lines:

```
Missing property: [Message.originConstraint.leafBean]
```

Do you see this getting merged if it we're able to (1) get to an acceptable path format and (2) include the detailed reported in the HTML and markdown outputs?

Related to #18

[gist_old]: https://gist.githubusercontent.com/thiagoarrais/1ceb28882eba3bd333e775de0ce69648/raw/7f734ff92b2265e8f08da55f3508c9135fdb0915/openapi-old.json
[gist_new]: https://gist.githubusercontent.com/thiagoarrais/1ceb28882eba3bd333e775de0ce69648/raw/7f734ff92b2265e8f08da55f3508c9135fdb0915/openapi-new.json